### PR TITLE
Support for long satellite names for -f -p -dp

### DIFF
--- a/predict.c
+++ b/predict.c
@@ -6238,7 +6238,7 @@ char argc, *argv[];
 			{
 				if ((strlen(quickstring)+strlen(argv[z]))<37)
 				{
-					strncat(quickstring,argv[z],20); // changed old value 15 to 20. this allows satellite names with more characters
+					strncat(quickstring,argv[z],20); // changed old value 15 to 20. this allows satellite names with more characters. 20 is max length for satellite networks naming conventions.
 					strcat(quickstring,"\n");
 					z++;
 				}
@@ -6255,7 +6255,7 @@ char argc, *argv[];
 			{
 				if ((strlen(quickstring)+strlen(argv[z]))<37)
 				{
-					strncat(quickstring,argv[z],20);// changed old value 15 to 20. this allows satellite names with more characters
+					strncat(quickstring,argv[z],20);// changed old value 15 to 20. this allows satellite names with more characters. 20 is max length for satellite networks naming conventions.
 					strcat(quickstring,"\n");
 					z++;
 				}
@@ -6272,7 +6272,7 @@ char argc, *argv[];
 			{
 				if ((strlen(quickstring)+strlen(argv[z]))<37)
 				{
-					strncat(quickstring,argv[z],20);// changed old value 15 to 20. this allows satellite names with more characters
+					strncat(quickstring,argv[z],20);// changed old value 15 to 20. this allows satellite names with more characters. 20 is max length for satellite networks naming conventions.
 					strcat(quickstring,"\n");
 					z++;
 				}


### PR DESCRIPTION
changed the string copy from 15 to 20 characters allowing larger satellite names (quickstring).
earlier if a satellite name is more than 15 characters then you won't get any quick predictions for -f -p -dp arguments.